### PR TITLE
Fix smartbear-zephyr in img-buildkite-64.json

### DIFF
--- a/img-buildkite-64.json
+++ b/img-buildkite-64.json
@@ -502,7 +502,7 @@
   },
   {
     "name": "zephyr",
-    "image": "img-buildkite-64/.png",
+    "image": "img-buildkite-64/smartbear-zephyr.png",
     "category": "Buildkite",
     "aliases": ["smartbear-zephyr"]
   },


### PR DESCRIPTION
### Description

<!--
Description of what the emoji is
link to the website of the emoji (if available)
-->


### PR checklist

* [ ] The image is 64x64 PNG image
* [ ] Image is added to `img-buildkite-64` directory
* [ ] Image is referenced in `img-buildkite-64.json` file
* [ ] Image is referenced in README markdown file
* [ ] The image can be hosted by Buildkite and made available in Buildkite UI
